### PR TITLE
Fix Inf/Sup

### DIFF
--- a/src/Data/Monoid/Inf.purs
+++ b/src/Data/Monoid/Inf.purs
@@ -52,4 +52,4 @@ instance semigroupInf :: (Lattice a) => Semigroup (Inf a) where
   append (Inf a) (Inf b) = Inf (a && b)
 
 instance monoidInf :: (BoundedLattice a) => Monoid (Inf a) where
-  mempty = Inf bottom
+  mempty = Inf top

--- a/src/Data/Monoid/Sup.purs
+++ b/src/Data/Monoid/Sup.purs
@@ -52,4 +52,4 @@ instance semigroupSup :: (Lattice a) => Semigroup (Sup a) where
   append (Sup a) (Sup b) = Sup (a || b)
 
 instance monoidSup :: (BoundedLattice a) => Monoid (Sup a) where
-  mempty = Sup top
+  mempty = Sup bottom


### PR DESCRIPTION
The `Monoid` instances for `Inf` and `Sup` have the identity elements the wrong way around. For example, at the moment we have that:

```
> Sup false <> mempty
Sup (true)
```