### PR TITLE
Add `power`

### DIFF
--- a/src/Data/Monoid.purs
+++ b/src/Data/Monoid.purs
@@ -1,11 +1,11 @@
 module Data.Monoid
   ( class Monoid, mempty
+  , power
   , module Data.Semigroup
   ) where
 
-import Data.Function (const)
+import Prelude
 import Data.Semigroup (class Semigroup, append, (<>))
-import Data.Unit (Unit, unit)
 
 -- | A `Monoid` is a `Semigroup` with a value `mempty`, which is both a
 -- | left and right unit for the associative operation `<>`:
@@ -31,3 +31,23 @@ instance monoidString :: Monoid String where
 
 instance monoidArray :: Monoid (Array a) where
   mempty = []
+
+-- | Append a value to itself a certain number of times. For the
+-- | `Multiplicative` type, and for a non-negative power, this is the same as
+-- | normal number exponentiation.
+-- |
+-- | If the second argument is negative this function will return `mempty`
+-- | (*unlike* normal number exponentiation). The `Monoid` constraint alone
+-- | is not enough to write a `power` function with the property that `power x
+-- | n` cancels with `power x (-n)`, i.e. `power x n <> power x (-n) = mempty`.
+-- | For that, we would additionally need the ability to invert elements, i.e.
+-- | a Group.
+power :: forall m. Monoid m => m -> Int -> m
+power x = go
+  where
+  go :: Int -> m
+  go p
+    | p <= 0         = mempty
+    | p == 1         = x
+    | p `mod` 2 == 0 = let x' = go (p/2) in x' <> x'
+    | otherwise      = let x' = go (p/2) in x' <> x' <> x


### PR DESCRIPTION
For repeatedly appending something with itself. See also
https://github.com/purescript/purescript-integers/pull/24

Eg:

```purescript
power "hi" 3 = "hihihi"
power (Additive 6) 7 = Additive 42
power (Multiplicative 2) 5 = Multiplicative 32
```

I decided to call this `power` as opposed to `pow` (as in `Math.pow` and `Data.Int.pow`) because the two `pow` functions both correspond to JS' `Math.pow` so it makes sense for them to be the same, but of course this function is a bit different. Also I guess it's nice to be able to have this function in the same scope with a `pow`?

Implementation is maybe a little naive w.r.t. how odd numbers are handled (the `otherwise` case) but I guess we can come back to that later if we ever need to.